### PR TITLE
Bump versions in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,26 +2,63 @@
 name = "rwc"
 version = "0.3.0"
 dependencies = [
- "docopt 0.6.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.6.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "docopt"
-version = "0.6.60"
+version = "0.6.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.27"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.12"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 


### PR DESCRIPTION
Doesn't seem to build on current nightly, so I regenerated Cargo.lock

```
   Compiling regex v0.1.27
   Compiling rustc-serialize v0.3.12
/home/remram/.multirust/toolchains/nightly/cargo/registry/src/github.com-0a35038f75765ae4/rustc-serialize-0.3.12/src/json.rs:244:16: 244:21 error: unresolved import `std::num::Float`. There is no `Float` in `std::num`
/home/remram/.multirust/toolchains/nightly/cargo/registry/src/github.com-0a35038f75765ae4/rustc-serialize-0.3.12/src/json.rs:244 use std::num::{Float, Int};
                                                                                                                                                ^~~~~
/home/remram/.multirust/toolchains/nightly/cargo/registry/src/github.com-0a35038f75765ae4/rustc-serialize-0.3.12/src/json.rs:244:23: 244:26 error: unresolved import `std::num::Int`. There is no `Int` in `std::num`
/home/remram/.multirust/toolchains/nightly/cargo/registry/src/github.com-0a35038f75765ae4/rustc-serialize-0.3.12/src/json.rs:244 use std::num::{Float, Int};
                                                                                                                                                       ^~~
/home/remram/.multirust/toolchains/nightly/cargo/registry/src/github.com-0a35038f75765ae4/rustc-serialize-0.3.12/src/serialize.rs:18:16: 18:23 error: unresolved import `std::ffi::AsOsStr`. There is no `AsOsStr` in `std::ffi`
/home/remram/.multirust/toolchains/nightly/cargo/registry/src/github.com-0a35038f75765ae4/rustc-serialize-0.3.12/src/serialize.rs:18 use std::ffi::{AsOsStr, OsString};
                                                                                                                                                    ^~~~~~~
error: aborting due to 3 previous errors
```
